### PR TITLE
fix: 修复校园卡多账户选择问题并兼容课程表空时间字段

### DIFF
--- a/src/card/card.rs
+++ b/src/card/card.rs
@@ -103,11 +103,28 @@ impl Card {
         );
 
         if let Some(Value::Array(data)) = json.get_mut("objs").map(Value::take) {
+            let available_card_types: Vec<String> = data
+                .iter()
+                .filter_map(|value| {
+                    value
+                        .get("cardTypeName")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                })
+                .collect();
+
             let card = data
                 .into_iter()
                 .find(|value| value.get("cardTypeName").and_then(Value::as_str) == Some("正式卡"))
-                .ok_or(ApiError::Website {
-                    msg: "No formal card found".to_string(),
+                .ok_or_else(|| ApiError::Website {
+                    msg: format!(
+                        "No formal card ('正式卡') found. Available cardTypeName values: {}",
+                        if available_card_types.is_empty() {
+                            "none".to_string()
+                        } else {
+                            available_card_types.join(", ")
+                        }
+                    ),
                 })?;
 
             serde_json::from_value(card).map_err(|err| ApiError::ModelParse {

--- a/src/card/card.rs
+++ b/src/card/card.rs
@@ -1,18 +1,15 @@
-//! 校园课余额、账单查询接口
+//! 校园卡余额、账单查询接口
 
 use reqwest::header::CONTENT_LENGTH;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, from_str};
 use serde_with::serde_as;
-use snafu::{OptionExt, ensure};
+use snafu::ensure;
 
 use crate::{
     card::utils::card_request_handler,
     errors,
-    errors::{
-        ApiError,
-        card::{CardError, CardResult},
-    },
+    errors::{ApiError, card::CardResult},
     session::{Client, Session},
     utils::{
         ApiModel,
@@ -24,13 +21,16 @@ use crate::{
 #[serde_as]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Card {
-    /// 校园卡id
+    /// 一卡通账户号
     #[serde(alias = "acctNo")]
     #[serde_as(deserialize_as = "serde_with::PickFirst<(_, serde_with::DisplayFromStr)>")]
     pub id: u64,
     /// 账户余额，单位为分
     #[serde(alias = "acctAmt")]
     pub amount: u64,
+    /// 账户状态
+    #[serde(alias = "acctStatus")]
+    pub account_status: Option<String>,
 }
 
 impl ApiModel for Card {}
@@ -51,6 +51,9 @@ pub struct Bill {
     /// 交易金额，单位为分
     #[serde(alias = "tranAmt")]
     pub tran_amount: i64,
+    /// 卡类型名称
+    #[serde(alias = "cardTypeName")]
+    pub card_type_name: Option<String>,
     /// 账户余额，单位为分
     #[serde(alias = "acctAmt")]
     #[serde_as(deserialize_as = "serde_with::DisplayFromStr")]
@@ -60,7 +63,7 @@ pub struct Bill {
 impl ApiModel for Bill {}
 
 impl Card {
-    /// 通过具有校园卡查询网址权限的会话([`Session`])，获取校园卡信息([`Card`])
+    /// 通过具有校园卡查询网址权限的会话([`Session`])，获取卡类型为“正式卡”的校园卡信息([`Card`])
     ///
     /// # Examples
     /// ```rust, no_run
@@ -83,7 +86,6 @@ impl Card {
         })
         .await?;
 
-        // the result is a json string, so parse response to string first
         let text = res.json::<String>().await?;
         let mut json = from_str::<Map<String, Value>>(&text).map_err(|_| ApiError::Website {
             msg: "Website response format incorrect".to_string(),
@@ -100,15 +102,22 @@ impl Card {
             }
         );
 
-        json.get_mut("objs")
-            .and_then(Value::as_array_mut)
-            .and_then(|array| array.get_mut(0))
-            .map(Value::take)
-            .map(serde_json::from_value)
-            .whatever_context::<&str, ApiError<CardError>>("Website response format incorrect")?
-            .map_err(|err| ApiError::ModelParse {
+        if let Some(Value::Array(data)) = json.get_mut("objs").map(Value::take) {
+            let card = data
+                .into_iter()
+                .find(|value| value.get("cardTypeName").and_then(Value::as_str) == Some("正式卡"))
+                .ok_or(ApiError::Website {
+                    msg: "No formal card found".to_string(),
+                })?;
+
+            serde_json::from_value(card).map_err(|err| ApiError::ModelParse {
                 msg: format!("Deserialize error: {}", err),
             })
+        } else {
+            Err(ApiError::Website {
+                msg: "Website response format incorrect".to_string(),
+            })
+        }
     }
 }
 

--- a/src/card/card.rs
+++ b/src/card/card.rs
@@ -102,30 +102,31 @@ impl Card {
             }
         );
 
-        if let Some(Value::Array(data)) = json.get_mut("objs").map(Value::take) {
-            let available_card_types: Vec<String> = data
-                .iter()
-                .filter_map(|value| {
-                    value
-                        .get("cardTypeName")
-                        .and_then(Value::as_str)
-                        .map(str::to_owned)
-                })
-                .collect();
+        if let Some(Value::Array(mut data)) = json.get_mut("objs").map(Value::take) {
+            fn card_type_name(value: &Value) -> Option<&str> {
+                value.get("cardTypeName").and_then(Value::as_str)
+            }
 
-            let card = data
-                .into_iter()
-                .find(|value| value.get("cardTypeName").and_then(Value::as_str) == Some("正式卡"))
-                .ok_or_else(|| ApiError::Website {
-                    msg: format!(
-                        "No formal card ('正式卡') found. Available cardTypeName values: {}",
-                        if available_card_types.is_empty() {
-                            "none".to_string()
-                        } else {
-                            available_card_types.join(", ")
-                        }
-                    ),
+            let card_index = data
+                .iter()
+                .position(|value| card_type_name(value) == Some("正式卡"))
+                .ok_or_else(|| {
+                    let available_card_types: Vec<_> =
+                        data.iter().filter_map(card_type_name).collect();
+                    let available_card_types_text = if available_card_types.is_empty() {
+                        "none".to_string()
+                    } else {
+                        available_card_types.join(", ")
+                    };
+
+                    ApiError::Website {
+                        msg: format!(
+                            "No formal card ('正式卡') found. Available cardTypeName values: {}",
+                            available_card_types_text,
+                        ),
+                    }
                 })?;
+            let card = data.remove(card_index);
 
             serde_json::from_value(card).map_err(|err| ApiError::ModelParse {
                 msg: format!("Deserialize error: {}", err),

--- a/src/mycqu/course/course_day_time.rs
+++ b/src/mycqu/course/course_day_time.rs
@@ -56,31 +56,39 @@ impl<'de> Deserialize<'de> for CourseDayTime {
                         Field::WeekDay => {
                             if weekday.is_none() {
                                 weekday = map.next_value().ok();
+                            } else {
+                                map.next_value::<serde::de::IgnoredAny>()?;
                             }
                         }
                         Field::WeekDayFormat => {
-                            if weekday.is_none()
-                                && let Some(weekday_str) = map.next_value::<Option<String>>()?
-                            {
-                                weekday =
-                                    Some(parse_weekday(&weekday_str).ok_or_else(|| {
-                                        serde::de::Error::custom("Invalid weekday")
-                                    })?);
+                            if weekday.is_none() {
+                                if let Some(weekday_str) = map.next_value::<Option<String>>()? {
+                                    weekday =
+                                        Some(parse_weekday(&weekday_str).ok_or_else(|| {
+                                            serde::de::Error::custom("Invalid weekday")
+                                        })?);
+                                }
+                            } else {
+                                map.next_value::<serde::de::IgnoredAny>()?;
                             }
                         }
                         Field::Period => {
                             if period.is_none() {
                                 period = map.next_value().ok();
+                            } else {
+                                map.next_value::<serde::de::IgnoredAny>()?;
                             }
                         }
                         Field::PeriodFormat => {
-                            if period.is_none()
-                                && let Some(period_str) = map.next_value::<Option<String>>()?
-                            {
-                                period =
-                                    Some(Period::parse_period_str(&period_str).ok_or_else(
-                                        || serde::de::Error::custom("Invalid period"),
-                                    )?);
+                            if period.is_none() {
+                                if let Some(period_str) = map.next_value::<Option<String>>()? {
+                                    period =
+                                        Some(Period::parse_period_str(&period_str).ok_or_else(
+                                            || serde::de::Error::custom("Invalid period"),
+                                        )?);
+                                }
+                            } else {
+                                map.next_value::<serde::de::IgnoredAny>()?;
                             }
                         }
                         Field::Unknown => {
@@ -102,6 +110,51 @@ impl<'de> Deserialize<'de> for CourseDayTime {
 }
 
 impl ApiModel for CourseDayTime {}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_deserialize_prefers_raw_fields_and_consumes_formatted_values() {
+        let course_day_time: CourseDayTime = serde_json::from_value(json!({
+            "weekDay": 4,
+            "weekDayFormat": "星期五",
+            "period": [3, 4],
+            "periodFormat": "3-4节",
+        }))
+        .unwrap();
+
+        assert_eq!(
+            course_day_time,
+            CourseDayTime {
+                weekday: 4,
+                period: Period { start: 3, end: 4 },
+            }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_accepts_null_formatted_fields() {
+        let course_day_time: CourseDayTime = serde_json::from_value(json!({
+            "weekDay": 4,
+            "weekDayFormat": null,
+            "period": [3, 4],
+            "periodFormat": null,
+        }))
+        .unwrap();
+
+        assert_eq!(
+            course_day_time,
+            CourseDayTime {
+                weekday: 4,
+                period: Period { start: 3, end: 4 },
+            }
+        );
+    }
+}
 
 impl CourseDayTime {
     /// 获取星期的较短中文表示

--- a/src/mycqu/course/course_day_time.rs
+++ b/src/mycqu/course/course_day_time.rs
@@ -59,13 +59,13 @@ impl<'de> Deserialize<'de> for CourseDayTime {
                             }
                         }
                         Field::WeekDayFormat => {
-                            if weekday.is_none() {
-                                if let Some(weekday_str) = map.next_value::<Option<String>>()? {
-                                    weekday =
-                                        Some(parse_weekday(&weekday_str).ok_or_else(|| {
-                                            serde::de::Error::custom("Invalid weekday")
-                                        })?);
-                                }
+                            if weekday.is_none()
+                                && let Some(weekday_str) = map.next_value::<Option<String>>()?
+                            {
+                                weekday =
+                                    Some(parse_weekday(&weekday_str).ok_or_else(|| {
+                                        serde::de::Error::custom("Invalid weekday")
+                                    })?);
                             }
                         }
                         Field::Period => {
@@ -74,13 +74,13 @@ impl<'de> Deserialize<'de> for CourseDayTime {
                             }
                         }
                         Field::PeriodFormat => {
-                            if period.is_none() {
-                                if let Some(period_str) = map.next_value::<Option<String>>()? {
-                                    period =
-                                        Some(Period::parse_period_str(&period_str).ok_or_else(
-                                            || serde::de::Error::custom("Invalid period"),
-                                        )?);
-                                }
+                            if period.is_none()
+                                && let Some(period_str) = map.next_value::<Option<String>>()?
+                            {
+                                period =
+                                    Some(Period::parse_period_str(&period_str).ok_or_else(
+                                        || serde::de::Error::custom("Invalid period"),
+                                    )?);
                             }
                         }
                         Field::Unknown => {

--- a/src/mycqu/course/course_day_time.rs
+++ b/src/mycqu/course/course_day_time.rs
@@ -60,10 +60,12 @@ impl<'de> Deserialize<'de> for CourseDayTime {
                         }
                         Field::WeekDayFormat => {
                             if weekday.is_none() {
-                                weekday =
-                                    Some(parse_weekday(&map.next_value::<String>()?).ok_or_else(
-                                        || serde::de::Error::custom("Invalid weekday"),
-                                    )?);
+                                if let Some(weekday_str) = map.next_value::<Option<String>>()? {
+                                    weekday =
+                                        Some(parse_weekday(&weekday_str).ok_or_else(|| {
+                                            serde::de::Error::custom("Invalid weekday")
+                                        })?);
+                                }
                             }
                         }
                         Field::Period => {
@@ -73,12 +75,12 @@ impl<'de> Deserialize<'de> for CourseDayTime {
                         }
                         Field::PeriodFormat => {
                             if period.is_none() {
-                                period = Some(
-                                    Period::parse_period_str(&map.next_value::<String>()?)
-                                        .ok_or_else(|| {
-                                            serde::de::Error::custom("Invalid period")
-                                        })?,
-                                );
+                                if let Some(period_str) = map.next_value::<Option<String>>()? {
+                                    period =
+                                        Some(Period::parse_period_str(&period_str).ok_or_else(
+                                            || serde::de::Error::custom("Invalid period"),
+                                        )?);
+                                }
                             }
                         }
                         Field::Unknown => {

--- a/src/mycqu/course/course_day_time.rs
+++ b/src/mycqu/course/course_day_time.rs
@@ -54,41 +54,37 @@ impl<'de> Deserialize<'de> for CourseDayTime {
                 while let Some(key) = map.next_key()? {
                     match key {
                         Field::WeekDay => {
+                            let value = map.next_value().ok();
+
                             if weekday.is_none() {
-                                weekday = map.next_value().ok();
-                            } else {
-                                map.next_value::<serde::de::IgnoredAny>()?;
+                                weekday = value;
                             }
                         }
                         Field::WeekDayFormat => {
-                            if weekday.is_none() {
-                                if let Some(weekday_str) = map.next_value::<Option<String>>()? {
-                                    weekday =
-                                        Some(parse_weekday(&weekday_str).ok_or_else(|| {
-                                            serde::de::Error::custom("Invalid weekday")
-                                        })?);
-                                }
-                            } else {
-                                map.next_value::<serde::de::IgnoredAny>()?;
+                            let value = map.next_value::<Option<String>>()?;
+
+                            if let (None, Some(weekday_str)) = (&weekday, value) {
+                                weekday =
+                                    Some(parse_weekday(&weekday_str).ok_or_else(|| {
+                                        serde::de::Error::custom("Invalid weekday")
+                                    })?);
                             }
                         }
                         Field::Period => {
+                            let value = map.next_value().ok();
+
                             if period.is_none() {
-                                period = map.next_value().ok();
-                            } else {
-                                map.next_value::<serde::de::IgnoredAny>()?;
+                                period = value;
                             }
                         }
                         Field::PeriodFormat => {
-                            if period.is_none() {
-                                if let Some(period_str) = map.next_value::<Option<String>>()? {
-                                    period =
-                                        Some(Period::parse_period_str(&period_str).ok_or_else(
-                                            || serde::de::Error::custom("Invalid period"),
-                                        )?);
-                                }
-                            } else {
-                                map.next_value::<serde::de::IgnoredAny>()?;
+                            let value = map.next_value::<Option<String>>()?;
+
+                            if let (None, Some(period_str)) = (&period, value) {
+                                period =
+                                    Some(Period::parse_period_str(&period_str).ok_or_else(
+                                        || serde::de::Error::custom("Invalid period"),
+                                    )?);
                             }
                         }
                         Field::Unknown => {
@@ -110,51 +106,6 @@ impl<'de> Deserialize<'de> for CourseDayTime {
 }
 
 impl ApiModel for CourseDayTime {}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use super::*;
-
-    #[test]
-    fn test_deserialize_prefers_raw_fields_and_consumes_formatted_values() {
-        let course_day_time: CourseDayTime = serde_json::from_value(json!({
-            "weekDay": 4,
-            "weekDayFormat": "星期五",
-            "period": [3, 4],
-            "periodFormat": "3-4节",
-        }))
-        .unwrap();
-
-        assert_eq!(
-            course_day_time,
-            CourseDayTime {
-                weekday: 4,
-                period: Period { start: 3, end: 4 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_deserialize_accepts_null_formatted_fields() {
-        let course_day_time: CourseDayTime = serde_json::from_value(json!({
-            "weekDay": 4,
-            "weekDayFormat": null,
-            "period": [3, 4],
-            "periodFormat": null,
-        }))
-        .unwrap();
-
-        assert_eq!(
-            course_day_time,
-            CourseDayTime {
-                weekday: 4,
-                period: Period { start: 3, end: 4 },
-            }
-        );
-    }
-}
 
 impl CourseDayTime {
     /// 获取星期的较短中文表示

--- a/src/mycqu/course/course_timetable.rs
+++ b/src/mycqu/course/course_timetable.rs
@@ -53,7 +53,9 @@ pub struct CourseTimetable {
     #[serde(default)]
     pub classroom_name: Option<String>,
     /// 实验课各次实验内容
-    #[serde_as(deserialize_as = "StringWithSeparator::<CommaSeparator, String>")]
+    #[serde_as(
+        deserialize_as = "serde_with::DefaultOnNull<StringWithSeparator::<CommaSeparator, String>>"
+    )]
     #[serde(alias = "exprProjectName")]
     #[serde(default)]
     pub expr_projects: Vec<String>,

--- a/src/mycqu/course/course_timetable.rs
+++ b/src/mycqu/course/course_timetable.rs
@@ -41,7 +41,9 @@ pub struct CourseTimetable {
     /// 行课的星期和节次
     ///
     /// 若时间是整周（如真实地占用整周的军训和某些实习、虚拟地使用一周的思修实践）则为[`None`]
+    #[serde_as(deserialize_as = "serde_with::DefaultOnError")]
     #[serde(flatten)]
+    #[serde(default)]
     pub day_time: Option<CourseDayTime>,
     /// 是否真实地占用整周（如军训和某些实习是真实地占用、思修实践是“虚拟地占用”）
     #[serde_as(deserialize_as = "serde_with::DefaultOnNull")]

--- a/src/mycqu/tests/course.rs
+++ b/src/mycqu/tests/course.rs
@@ -170,6 +170,44 @@ fn test_parse_course_day_time() {
 }
 
 #[rstest]
+fn test_parse_course_day_time_prefers_raw_fields_and_consumes_formatted_values() {
+    let course_day_time: CourseDayTime = serde_json::from_value(json!({
+        "weekDay": 4,
+        "weekDayFormat": "星期五",
+        "period": [3, 4],
+        "periodFormat": "3-4节",
+    }))
+    .unwrap();
+
+    assert_eq!(
+        course_day_time,
+        CourseDayTime {
+            weekday: 4,
+            period: Period { start: 3, end: 4 },
+        }
+    );
+}
+
+#[rstest]
+fn test_parse_course_day_time_accepts_null_formatted_fields() {
+    let course_day_time: CourseDayTime = serde_json::from_value(json!({
+        "weekDay": 4,
+        "weekDayFormat": null,
+        "period": [3, 4],
+        "periodFormat": null,
+    }))
+    .unwrap();
+
+    assert_eq!(
+        course_day_time,
+        CourseDayTime {
+            weekday: 4,
+            period: Period { start: 3, end: 4 },
+        }
+    );
+}
+
+#[rstest]
 fn test_parse_course_timetable(example_course: Course) {
     let json_value: Value = serde_json::from_str(include_str!("course_timetable.json")).unwrap();
     let course_timetable: CourseTimetable = serde_json::from_value(json_value).unwrap();
@@ -185,6 +223,33 @@ fn test_parse_course_timetable(example_course: Course) {
                 weekday: 4,
                 period: Period { start: 3, end: 4 },
             }),
+            whole_week: false,
+            classroom_name: Some("DYC101".to_string()),
+            expr_projects: vec![],
+        }
+    )
+}
+
+#[rstest]
+fn test_parse_course_timetable_uses_none_for_null_day_time(example_course: Course) {
+    let mut json_value: Value =
+        serde_json::from_str(include_str!("course_timetable.json")).unwrap();
+    let json_object = json_value.as_object_mut().unwrap();
+    json_object.insert("weekDay".to_string(), Value::Null);
+    json_object.insert("weekDayFormat".to_string(), Value::Null);
+    json_object.insert("period".to_string(), Value::Null);
+    json_object.insert("periodFormat".to_string(), Value::Null);
+
+    let course_timetable: CourseTimetable = serde_json::from_value(json_value).unwrap();
+
+    assert_eq!(
+        course_timetable,
+        CourseTimetable {
+            course: example_course,
+            stu_num: Some(117),
+            classroom: None,
+            weeks: vec![Period { start: 14, end: 17 }],
+            day_time: None,
             whole_week: false,
             classroom_name: Some("DYC101".to_string()),
             expr_projects: vec![],


### PR DESCRIPTION
## 概述

修复校园卡与课程表两个接口的解析问题，提升 `rsmycqu` 在实际返回数据变化下的兼容性。

## 变更内容

- 修复校园卡账户选择逻辑，不再默认取接口返回的第一项
- 从全部校园卡账户中筛选 `cardTypeName` 为 `正式卡` 的账户
- 在未找到正式卡账户时返回明确错误
- 为 `Card` 暴露 `acctStatus` 字段
- 为 `Bill` 暴露 `cardTypeName` 字段
- 修复课程表时间字段解析逻辑
- 在 `weekDayFormat` 或 `periodFormat` 为 `null` 时，优先使用已有原始字段并避免反序列化失败
- 保持课程表接口对可空格式化字段的兼容性

fix #27 