### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/321CQU/rsmycqu/compare/v0.2.2...v0.3.0) - 2026-05-07
+
+### Added
+
+- [**breaking**] include raw response in model parse errors ([#33](https://github.com/321CQU/rsmycqu/pull/33))
+
+### Other
+
+- *(deps)* migrate html parser to scraper ([#35](https://github.com/321CQU/rsmycqu/pull/35))
+- *(deps)* upgrade RustCrypto crates ([#34](https://github.com/321CQU/rsmycqu/pull/34))
+
 ## [0.2.2](https://github.com/321CQU/rsmycqu/compare/v0.2.1...v0.2.2) - 2026-01-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmycqu"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 authors = ["ZhuLegend"]
 description = "A Rust library for interacting with Chonqing University services, including SSO authentication, campus card management, and more."


### PR DESCRIPTION



## 🤖 New release

* `rsmycqu`: 0.2.2 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `rsmycqu` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field raw_response of variant ApiError::ModelParse in /tmp/.tmpEExcce/rsmycqu/src/errors/mod.rs:68
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/321CQU/rsmycqu/compare/v0.2.2...v0.3.0) - 2026-05-07

### Added

- [**breaking**] include raw response in model parse errors ([#33](https://github.com/321CQU/rsmycqu/pull/33))

### Other

- *(deps)* migrate html parser to scraper ([#35](https://github.com/321CQU/rsmycqu/pull/35))
- *(deps)* upgrade RustCrypto crates ([#34](https://github.com/321CQU/rsmycqu/pull/34))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).