### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/321CQU/rsmycqu/compare/v0.3.0...v0.4.0) - 2026-05-09
+
+### Fixed
+
+- 修复校园卡多账户选择问题并兼容课程表空时间字段 ([#28](https://github.com/321CQU/rsmycqu/pull/28))
+
+### Other
+
+- *(deps)* update snafu requirement from 0.8.5 to 0.9.0 ([#26](https://github.com/321CQU/rsmycqu/pull/26))
+- improve Rust workflow caching ([#38](https://github.com/321CQU/rsmycqu/pull/38))
+
 ## [0.3.0](https://github.com/321CQU/rsmycqu/compare/v0.2.2...v0.3.0) - 2026-05-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmycqu"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["ZhuLegend"]
 description = "A Rust library for interacting with Chonqing University services, including SSO authentication, campus card management, and more."


### PR DESCRIPTION



## 🤖 New release

* `rsmycqu`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `rsmycqu` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Bill.card_type_name in /tmp/.tmpuTn9re/rsmycqu/src/card/card.rs:57
  field Card.account_status in /tmp/.tmpuTn9re/rsmycqu/src/card/card.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/321CQU/rsmycqu/compare/v0.3.0...v0.4.0) - 2026-05-09

### Fixed

- 修复校园卡多账户选择问题并兼容课程表空时间字段 ([#28](https://github.com/321CQU/rsmycqu/pull/28))

### Other

- *(deps)* update snafu requirement from 0.8.5 to 0.9.0 ([#26](https://github.com/321CQU/rsmycqu/pull/26))
- improve Rust workflow caching ([#38](https://github.com/321CQU/rsmycqu/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).