### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/321CQU/rsmycqu/compare/v0.4.0...v0.4.1) - 2026-05-10
+
+### Fixed
+
+- parse exam string number fields ([#39](https://github.com/321CQU/rsmycqu/pull/39))
+
 ## [0.4.0](https://github.com/321CQU/rsmycqu/compare/v0.3.0...v0.4.0) - 2026-05-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmycqu"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["ZhuLegend"]
 description = "A Rust library for interacting with Chonqing University services, including SSO authentication, campus card management, and more."


### PR DESCRIPTION



## 🤖 New release

* `rsmycqu`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/321CQU/rsmycqu/compare/v0.4.0...v0.4.1) - 2026-05-10

### Fixed

- parse exam string number fields ([#39](https://github.com/321CQU/rsmycqu/pull/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).