### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/321CQU/rsmycqu/compare/v0.4.1...v0.4.2) - 2026-05-12
+
+### Fixed
+
+- handle null exam invigilator lists ([#42](https://github.com/321CQU/rsmycqu/pull/42))
+
+### Other
+
+- *(deps)* update scraper requirement from 0.26.0 to 0.27.0 ([#41](https://github.com/321CQU/rsmycqu/pull/41))
+
 ## [0.4.1](https://github.com/321CQU/rsmycqu/compare/v0.4.0...v0.4.1) - 2026-05-10
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmycqu"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["ZhuLegend"]
 description = "A Rust library for interacting with Chonqing University services, including SSO authentication, campus card management, and more."


### PR DESCRIPTION



## 🤖 New release

* `rsmycqu`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/321CQU/rsmycqu/compare/v0.4.1...v0.4.2) - 2026-05-12

### Fixed

- handle null exam invigilator lists ([#42](https://github.com/321CQU/rsmycqu/pull/42))

### Other

- *(deps)* update scraper requirement from 0.26.0 to 0.27.0 ([#41](https://github.com/321CQU/rsmycqu/pull/41))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).